### PR TITLE
Update template_server.rb

### DIFF
--- a/template_server.rb
+++ b/template_server.rb
@@ -58,10 +58,14 @@ class GHAapp < Sinatra::Application
 
   post '/event_handler' do
 
-    # # # # # # # # # # # #
-    # ADD YOUR CODE HERE  #
-    # # # # # # # # # # # #
-
+   # Get the event type from the HTTP_X_GITHUB_EVENT header
+case request.env['HTTP_X_GITHUB_EVENT']
+when 'check_suite'
+  # A new check_suite has been created. Create a new check run with status queued
+  if @payload['action'] == 'requested' || @payload['action'] == 'rerequested'
+    create_check_run
+  end
+end
     200 # success status
   end
 


### PR DESCRIPTION
# Create a new check run with the status queued
def create_check_run
  # # At the time of writing, Octokit does not support the Checks API yet, but
  # it does provide generic HTTP methods you can use:
  # /rest/reference/checks#create-a-check-run
  check_run = @installation_client.post(
    "repos/#{@payload['repository']['full_name']}/check-runs",
    {
      accept: 'application/vnd.github.v3+json',
      # The name of your check run.
      name: 'Octo RuboCop',
      # The payload structure differs depending on whether a check run or a check suite event occurred.
      head_sha: @payload['check_run'].nil? ? @payload['check_suite']['head_sha'] : @payload['check_run']['head_sha']
    }
  )
end